### PR TITLE
Include MAGNET fixes (by reverting the commit "fixing and making MAGNET eval more efficient)

### DIFF
--- a/bash/download_models.sh
+++ b/bash/download_models.sh
@@ -11,17 +11,14 @@
 
 set -e
 
-BASE_DIR=$FAST/ga_files
+BASE_DIR=/leonardo_work/IscrC_CALAMITA
 export TOKENIZERS_PARALLELISM=false
-export HF_HOME=$BASE_DIR/huggingface
+export HF_HOME=$BASE_DIR/calamita/huggingface
 source venv/bin/activate
 echo "This script has to be run only once with internet access"
 
 MODELS=( \
     meta-llama/Llama-3.1-70B-Instruct \
-    sapienzanlp/Minerva-7B-instruct-v1.0 \
-    sapienzanlp/Minerva-7B-instruct-v1.0 \
-    meta-llama/Llama-3.1-8B-Instruct \
 )
 
 # Download models, tokenizers, and config files

--- a/bash/run_model.sh
+++ b/bash/run_model.sh
@@ -6,7 +6,7 @@
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=8
 #SBATCH --gpus-per-node=4
-#SBATCH --time=04:00:00
+#SBATCH --time=01:00:00
 #SBATCH --mem-per-gpu=32G
 #SBATCH --account=IscrC_CALAMITA
 
@@ -16,19 +16,17 @@ if [ "$#" -ne 2 ]; then
 	exit 1
 fi
 
-BASE_DIR=$FAST/ga_files
+BASE_DIR=/leonardo_work/IscrC_CALAMITA
 export TOKENIZERS_PARALLELISM=false
-export HF_HOME=$BASE_DIR/huggingface
+export HF_HOME=$BASE_DIR/calamita/huggingface
 export TRANSFORMERS_OFFLINE="1"
 export HF_DATASETS_OFFLINE="1"
-export HF_EVALUATE_OFFLINE="1"
-export BLEURT_CHECKPOINT=$BASE_DIR/BLEURT-20
 
 source venv/bin/activate
 MODEL=$1
 
-BATCH_SIZE=auto
-OUTPUT_DIR=$BASE_DIR/results_calamita
+BATCH_SIZE=1
+OUTPUT_DIR=$BASE_DIR/tests_calamita
 
 module unload cuda
 module load cuda/12.3
@@ -40,20 +38,16 @@ echo "Tasks:"
 echo $tasks
 
 NUM_GPUS=$SLURM_GPUS_PER_NODE
-NUM_GPUS=4
 echo "NUM_GPUS: $NUM_GPUS"
 
 # accelerate launch \
     # --num_machines 1 \
     # --num_processes 1 \
     # -m 
-# lm_eval --model hf \
-    # --model_args pretrained=${MODEL},dtype=float16,parallelize=True \
-
-# export CUDA_VISIBLE_DEVICES=0
-
+# lm_eval --model lm \
+#     --model_args pretrained=${MODEL},dtype=float16,parallelize=True \
 lm_eval --model vllm \
-    --model_args pretrained=${MODEL},dtype=bfloat16,gpu_memory_utilization=0.8,max_model_len=3072,tensor_parallel_size=$NUM_GPUS \
+    --model_args pretrained=${MODEL},dtype=float16,tensor_parallel_size=$NUM_GPUS,gpu_memory_utilization=0.9,max_model_len=2048 \
     --tasks ${tasks} \
     --output_path ${OUTPUT_DIR} \
     --batch_size $BATCH_SIZE \
@@ -64,4 +58,4 @@ lm_eval --model vllm \
     --include_path ./tasks \
     --load_local \
     --local_base_dir $BASE_DIR/local_datasets \
-    --unload_lm_before_eval
+    --limit 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 tyro
 unbabel-comet
-git+https://github.com/lucadiliello/bleurt-pytorch.git
-# git+https://github.com/google-research/bleurt.git
+git+https://github.com/google-research/bleurt.git

--- a/tasks/MAGNET/MAGNET_IT_en_it_private.yaml
+++ b/tasks/MAGNET/MAGNET_IT_en_it_private.yaml
@@ -29,12 +29,19 @@ process_results: !function utils.process_results_en_it
 
 # takes the value of the "metric" key from the dict returned by the "process_results" function
 metric_list:
-  - metric: bleu
-  - metric: chrf
-  - metric: !function utils.comet_22_da    # passthrough
-    aggregation: !function utils.comet_22_da_agg
-  - metric: !function utils.bleurt    # passthrough
-    aggregation: !function utils.bleurt_agg
+  - metric: bleu_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: chrf_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: bleurt_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: comet_score     # my score
+    aggregation: mean
+    higher_is_better: true
+
 
 metadata:
   version: 1.0

--- a/tasks/MAGNET/MAGNET_IT_it_en_private.yaml
+++ b/tasks/MAGNET/MAGNET_IT_it_en_private.yaml
@@ -29,12 +29,18 @@ process_results: !function utils.process_results_it_en
 
 # takes the value of the "metric" key from the dict returned by the "process_results" function
 metric_list:
-  - metric: bleu
-  - metric: chrf
-  - metric: !function utils.comet_22_da    # passthrough
-    aggregation: !function utils.comet_22_da_agg
-  - metric: !function utils.bleurt    # passthrough
-    aggregation: !function utils.bleurt_agg
+  - metric: bleu_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: chrf_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: bleurt_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: comet_score     # my score
+    aggregation: mean
+    higher_is_better: true
 
 
 metadata:

--- a/tasks/MAGNET/MAGNET_UK_en_it_private.yaml
+++ b/tasks/MAGNET/MAGNET_UK_en_it_private.yaml
@@ -29,12 +29,18 @@ process_results: !function utils.process_results_en_it
 
 # takes the value of the "metric" key from the dict returned by the "process_results" function
 metric_list:
-  - metric: bleu
-  - metric: chrf
-  - metric: !function utils.comet_22_da    # passthrough
-    aggregation: !function utils.comet_22_da_agg
-  - metric: !function utils.bleurt    # passthrough
-    aggregation: !function utils.bleurt_agg
+  - metric: bleu_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: chrf_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: bleurt_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: comet_score     # my score
+    aggregation: mean
+    higher_is_better: true
 
 
 metadata:

--- a/tasks/MAGNET/MAGNET_UK_it_en_private.yaml
+++ b/tasks/MAGNET/MAGNET_UK_it_en_private.yaml
@@ -29,12 +29,18 @@ process_results: !function utils.process_results_it_en
 
 # takes the value of the "metric" key from the dict returned by the "process_results" function
 metric_list:
-  - metric: bleu
-  - metric: chrf
-  - metric: !function utils.comet_22_da    # passthrough
-    aggregation: !function utils.comet_22_da_agg
-  - metric: !function utils.bleurt    # passthrough
-    aggregation: !function utils.bleurt_agg
+  - metric: bleu_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: chrf_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: bleurt_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: comet_score     # my score
+    aggregation: mean
+    higher_is_better: true
 
 
 metadata:

--- a/tasks/MAGNET/MAGNET_US_en_it_private.yaml
+++ b/tasks/MAGNET/MAGNET_US_en_it_private.yaml
@@ -29,12 +29,18 @@ process_results: !function utils.process_results_en_it
 
 # takes the value of the "metric" key from the dict returned by the "process_results" function
 metric_list:
-  - metric: bleu
-  - metric: chrf
-  - metric: !function utils.comet_22_da    # passthrough
-    aggregation: !function utils.comet_22_da_agg
-  - metric: !function utils.bleurt    # passthrough
-    aggregation: !function utils.bleurt_agg
+  - metric: bleu_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: chrf_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: bleurt_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: comet_score     # my score
+    aggregation: mean
+    higher_is_better: true
 
 
 metadata:

--- a/tasks/MAGNET/MAGNET_US_it_en_private.yaml
+++ b/tasks/MAGNET/MAGNET_US_it_en_private.yaml
@@ -29,12 +29,18 @@ process_results: !function utils.process_results_it_en
 
 # takes the value of the "metric" key from the dict returned by the "process_results" function
 metric_list:
-  - metric: bleu
-  - metric: chrf
-  - metric: !function utils.comet_22_da    # passthrough
-    aggregation: !function utils.comet_22_da_agg
-  - metric: !function utils.bleurt    # passthrough
-    aggregation: !function utils.bleurt_agg
+  - metric: bleu_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: chrf_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: bleurt_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: comet_score     # my score
+    aggregation: mean
+    higher_is_better: true
 
 
 metadata:

--- a/tasks/MAGNET/MAGNET_en_it_public.yaml
+++ b/tasks/MAGNET/MAGNET_en_it_public.yaml
@@ -29,12 +29,18 @@ process_results: !function utils.process_results_en_it
 
 # takes the value of the "metric" key from the dict returned by the "process_results" function
 metric_list:
-  - metric: bleu
-  - metric: chrf
-  - metric: !function utils.comet_22_da    # passthrough
-    aggregation: !function utils.comet_22_da_agg
-  - metric: !function utils.bleurt    # passthrough
-    aggregation: !function utils.bleurt_agg
+  - metric: bleu_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: chrf_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: bleurt_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: comet_score     # my score
+    aggregation: mean
+    higher_is_better: true
 
 
 metadata:

--- a/tasks/MAGNET/MAGNET_it_en_public.yaml
+++ b/tasks/MAGNET/MAGNET_it_en_public.yaml
@@ -29,12 +29,18 @@ process_results: !function utils.process_results_it_en
 
 # takes the value of the "metric" key from the dict returned by the "process_results" function
 metric_list:
-  - metric: bleu
-  - metric: chrf
-  - metric: !function utils.comet_22_da    # passthrough
-    aggregation: !function utils.comet_22_da_agg
-  - metric: !function utils.bleurt    # passthrough
-    aggregation: !function utils.bleurt_agg
+  - metric: bleu_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: chrf_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: bleurt_score    # my score
+    aggregation: mean
+    higher_is_better: true
+  - metric: comet_score     # my score
+    aggregation: mean
+    higher_is_better: true
 
 
 metadata:

--- a/tasks/MAGNET/utils.py
+++ b/tasks/MAGNET/utils.py
@@ -1,10 +1,8 @@
 import datasets
 
+from typing import List
 from evaluate import load
 import os
-import numpy as np
-from tqdm import tqdm
-from functools import partial
 
 # bleu_metric = load("bleu")
 # chrf_metric = load("chrf")
@@ -111,55 +109,56 @@ def single_comet(source: str, ref: str, pred: str) -> float:
     return comet_score["scores"][0]
 
 
-# def _get_metrics(
-#     model_input: str,
-#     reference_out: str,
-#     completition: str
-#     ) -> dict[str, float]:
-#     """
-#     Compute the metrics for the MT_CALAMITA task
-#     """
 
-#     # clean completion
-#     completition = _search_delimiters(completition)
+def _get_metrics(
+    model_input: str,
+    reference_out: str,
+    completition: str
+    ) -> dict[str, float]:
+    """
+    Compute the metrics for the MT_CALAMITA task
+    """
 
-#     # BLEU
-#     bleu_score = single_bleu(ref=reference_out, pred=completition)
-#     # CHRF
-#     chrf_score = sigle_chrf(ref=reference_out, pred=completition)
-#     # BLEURT
-#     bleurt_score = single_bleurt(ref=reference_out, pred=completition)
-#     # COMET
-#     comet_score = single_comet(source=model_input, ref=reference_out, pred=completition)
+    # clean completion
+    completition = _search_delimiters(completition)
 
-#     return {
-#         "bleu_score": bleu_score,
-#         "chrf_score": chrf_score,
-#         "bleurt_score": bleurt_score,
-#         "comet_score": comet_score,
-#     }
+    # BLEU
+    bleu_score = single_bleu(ref=reference_out, pred=completition)
+    # CHRF
+    chrf_score = sigle_chrf(ref=reference_out, pred=completition)
+    # BLEURT
+    bleurt_score = single_bleurt(ref=reference_out, pred=completition)
+    # COMET
+    comet_score = single_comet(source=model_input, ref=reference_out, pred=completition)
+
+    return {
+        "bleu_score": bleu_score,
+        "chrf_score": chrf_score,
+        "bleurt_score": bleurt_score,
+        "comet_score": comet_score,
+    }
 
 
-# def process_results_it_en(doc, results):
-#     """
-#     Process the results of the model and return the metrics. Implementation for the **italian to english** task
-#     Args:
-#         - doc: the document containing the input and output (keys are the variables from the prompt_template)
-#         - results: the output of the model (still dunnow why its a list but it doesn't depend on the batchsize)
-#     Returns:
-#         - a dictionary containing the metrics (metric_name: metric_value)
-#     """
+def process_results_it_en(doc, results):
+    """
+    Process the results of the model and return the metrics. Implementation for the **italian to english** task
+    Args:
+        - doc: the document containing the input and output (keys are the variables from the prompt_template)
+        - results: the output of the model (still dunnow why its a list but it doesn't depend on the batchsize)
+    Returns:
+        - a dictionary containing the metrics (metric_name: metric_value)
+    """
 
-#     completion = results[0]
-#     model_input, reference_out = doc["italian"], doc["english"]
+    completion = results[0]
+    model_input, reference_out = doc["italian"], doc["english"]
 
-#     return _get_metrics(
-#         model_input=model_input, 
-#         reference_out=reference_out, 
-#         completition=completion,
-#     )
+    return _get_metrics(
+        model_input=model_input, 
+        reference_out=reference_out, 
+        completition=completion,
+    )
 
-def process_results(doc, results, src_col, ref_col):
+def process_results_en_it(doc, results):
     """
     Process the results of the model and return the metrics. Implementation for the **english to italian** task
     Args:
@@ -170,74 +169,14 @@ def process_results(doc, results, src_col, ref_col):
     """
 
     completion = results[0]
-    model_input, reference_out = doc[src_col], doc[ref_col]
-    items = [reference_out, completion, model_input]
-    items = [
-        i if i is not None else "" for i in items
-    ]
+    model_input, reference_out = doc["english"], doc["italian"]
 
-    return {
-        "bleu": items[:2],
-        "chrf": items[:2],
-        "comet_22_da": items,
-        "bleurt": items[:2],
-    }
+    return _get_metrics(
+        model_input=model_input, 
+        reference_out=reference_out, 
+        completition=completion,
+    )
 
 
-process_results_en_it = partial(process_results, src_col="english", ref_col="italian")
-process_results_it_en = partial(process_results, src_col="italian", ref_col="english")
 
 
-def bleurt_agg(items):
-    from bleurt_pytorch import BleurtConfig, BleurtForSequenceClassification, BleurtTokenizer
-    import torch
-
-    config = BleurtConfig.from_pretrained("lucadiliello/BLEURT-20")
-    model = BleurtForSequenceClassification.from_pretrained("lucadiliello/BLEURT-20")
-    tokenizer = BleurtTokenizer.from_pretrained("lucadiliello/BLEURT-20")
-    model.eval()
-
-    refs = list(zip(*items))[0]
-    preds = list(zip(*items))[1]
-    batch_size = 4
-    ref_batches = np.array_split(refs, len(refs) // batch_size)
-    pred_batches = np.array_split(preds, len(preds) // batch_size)
-
-    with torch.no_grad():
-        results = list()
-        for ref_batch, pred_batch in tqdm(zip(ref_batches, pred_batches), desc="Batch BLEURT", total=len(ref_batches)):
-            inputs = tokenizer(list(ref_batch), list(pred_batch), padding='longest', return_tensors='pt')
-            # move the inputs to the GPU
-            inputs = {k: v.to(model.device) for k, v in inputs.items()}
-            # compute the logits
-            res = model(**inputs).logits.flatten().tolist()
-            results.extend(res)
-
-    return np.mean(results)
-
-
-def bleurt(items):  # This is a passthrough function
-    return items
-
-
-def comet_22_da_agg(items):
-    from comet import download_model, load_from_checkpoint
-    import torch
-    
-    model_path = download_model("Unbabel/wmt22-comet-da")
-    model = load_from_checkpoint(model_path)
-
-    refs = list(zip(*items))[0]
-    preds = list(zip(*items))[1]
-    sources = list(zip(*items))[2]
-    batch_size = 4
-
-    data = [
-        {"src": src, "mt": mt, "ref": ref}
-        for src, mt, ref in zip(sources, preds, refs)
-    ]
-    output = model.predict(data, batch_size=batch_size, gpus=1)
-    return output.system_score
-
-def comet_22_da(items):  # This is a passthrough function
-    return items


### PR DESCRIPTION
Include several improvements on how MAGNET results and outputs are computed.
Note: it requires the most updated version of the lm-eval-harness fork [here](https://github.com/deep-spin/lm-evaluation-harness) 

Fundamentally, this PR reverts commit 799673f6855c4b73be2ed402b2665bd4625be839.